### PR TITLE
Updated ARM filters in .bonsai.yml to use entity.system.arm_version i…

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -31,4 +31,5 @@
     sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
     filter:
     -  "entity.system.os == 'linux'"
-    -  "entity.system.arch == 'armv7'"
+    -  "entity.system.arch == 'arm'"
+    -  "entity.system.arm_version == 7"


### PR DESCRIPTION
…nstead of only arch. This has been discussed with Sensu in https://github.com/sensu/sensu-go/issues/3563 and https://github.com/sensu-community/check-plugin-template/issues/11. This makes it possible for arm7 devices (Rapsberry Pi) to get an asset without needing to modify the Asset Definition manually.