### PR TITLE
Added support for arm v6. Raspberry Pi OS registeres arm_version=6, t…

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -24,7 +24,16 @@
     filter:
     -  "entity.system.os == 'linux'"
     -  "entity.system.arch == 'arm64'"
-  
+
+  - platform: "linux"
+    arch: "armv6"
+    asset_filename: "#{repo}_#{version}_linux_armv6.tar.gz"
+    sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+    filter:
+      -  "entity.system.os == 'linux'"
+      -  "entity.system.arch == 'arm'"
+      -  "entity.system.arm_version == 6"
+
   - platform: "linux"
     arch: "armv7"
     asset_filename: "#{repo}_#{version}_linux_armv7.tar.gz"


### PR DESCRIPTION
…o support both rmv6 and armv7 devices. So to make it work we also need armv6 builds.